### PR TITLE
adding tooltip reference to MCAdmin

### DIFF
--- a/index.php
+++ b/index.php
@@ -26,9 +26,6 @@
   <link rel="alternate stylesheet" type="text/css" href="css/darkmode.css?q=1.1" title="darkmode">
   <link rel="alternate stylesheet" type="text/css" href="https://unpkg.com/tippy.js@3.3.0/dist/themes/google.css" id="darkmode">
  
-
-  
-
   <!-- Navbar & info icons
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -26,9 +26,12 @@
 	  '<div class="tooltip">' +
 
 	  '<div class="tooltip-tip"><i class="far fa-lightbulb"></i>The hashed User ID can be found within the Connected Sites script as the first of two 25-digit hexdecimal strings that make up part of the chimpstatic.com url.</div>' +
-	
+	  
+	  '<div class="tooltip-tip"><i class="far fa-lightbulb"></i>If a User ID is detected, click the linked ID in the column on the right to view the account in MCAdmin.</div>' +
+	 
 	  '<div class="tooltip-snippet">&lt;script id=&quot;mcjs&quot;&gt;!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,&quot;script&quot;,&quot;https://chimpstatic.com/mcjs-connected/js/users/<span class="tooltip-note">219ec3282ae742b42f62a07e8</span>/f660b56ff295be3ad55969481.js&quot;);&lt;/script&gt;</div>' +
 	  '</div>' 
+
 	})
 	
 	// Connected Sites Tooltip:


### PR DESCRIPTION
Adding tooltip to clarify that hashed UID in right column is a hyperlink to the account in MCAdmin.